### PR TITLE
Improved JSON binder

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -22,7 +22,8 @@ func main() {
 		rpc.WithPrefix("v2"),
 	)
 
-	go runClientTest()
+	//go runClientTest()
+	fmt.Println("[SERVER] Running on :8080")
 	http.ListenAndServe(":8080", gw)
 }
 
@@ -45,6 +46,7 @@ func runClientTest() {
 	response, err := client.GetByID(ctx, &example.GetByIDRequest{
 		ID:   "123x45",
 		Flag: false,
+		Flip: true,
 	})
 	fmt.Printf(">>>>>> %+v : %v", response, err)
 }

--- a/example/group_service.go
+++ b/example/group_service.go
@@ -23,8 +23,18 @@ type GroupService interface {
 }
 
 type GetByIDRequest struct {
-	ID   string `json:"id"`
-	Flag bool   `json:"flag"`
+	ID   string  `json:"id"`
+	Flag bool    `json:"flag"`
+	Flip Flipper `json:"flip"`
+	Page Paging  `json:"page"`
+}
+
+type Flipper bool
+
+type Paging struct {
+	Limit  int
+	Offset int
+	Sort   string
 }
 
 type GetByIDResponse struct {

--- a/example/group_service_server.go
+++ b/example/group_service_server.go
@@ -19,6 +19,8 @@ func (svc GroupServiceServer) GetByID(ctx context.Context, request *GetByIDReque
 	var other2 GetByIDRequest
 	metadata.Value(ctx, "bar", &other2)
 	callName := ctx.Value("ServiceCall")
+
+	fmt.Printf("\nINCOMING:::: ID[%s] Flag[%v] Flip[%v] Page[%+v]\n\n", request.ID, request.Flag, request.Flip, request.Page)
 	return &GetByIDResponse{
 		ID:          request.ID,
 		Name:        fmt.Sprintf("The Bees: [id=%s][flag=%v]", request.ID, request.Flag),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
 	github.com/robsignorelli/respond v0.2.0
-	github.com/spf13/cobra v1.1.1 // indirect
+	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.4.0
 )

--- a/internal/reflection/reflection.go
+++ b/internal/reflection/reflection.go
@@ -30,24 +30,35 @@ func StructToMap(item interface{}) map[string]interface{} {
 	return res
 }
 
+var noField = reflect.StructField{}
+
+func FindField(structType reflect.Type, name string) (reflect.StructField, bool) {
+	for i := 0; i < structType.NumField(); i++ {
+		field := structType.Field(i)
+		if strings.EqualFold(name, FieldName(field)) {
+			return field, true
+		}
+	}
+	return noField, false
+}
+
 func FieldName(field reflect.StructField) string {
-	tag := field.Tag.Get("json")
-	if tag == "" || tag == "-" {
+	jsonTag := field.Tag.Get("json")
+	if jsonTag == "" || jsonTag == "-" {
 		return field.Name
 	}
 
-	switch comma := strings.IndexRune(tag, ','); {
-	case comma == 0:
-		// Ill-formed JSON tag
+	// Parse the `json` tag to determine how the user has re-mapped the field.
+	switch comma := strings.IndexRune(jsonTag, ','); comma {
+	case -1:
+		// e.g. `json:"firstName"`
+		return jsonTag
+	case 0:
+		// e.g. `json:",omitempty"` (not remapped so use fields actual name)
 		return field.Name
-
-	case comma >= 0:
-		// It's something like "json:name,omitempty", so strip off just the remapped name, not the other options.
-		return tag[0:comma]
-
 	default:
-		// The whole json tag is the remapped field name (e.g. "json:name")
-		return tag
+		// e.g. `json:"firstName,omitempty" (just use the remapped name)
+		return jsonTag[0:comma]
 	}
 }
 

--- a/rpc/binding.go
+++ b/rpc/binding.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/robsignorelli/frodo/internal/reflection"
+	"github.com/robsignorelli/frodo/rpc/errors"
 )
 
 // Binder performs the work of taking all meaningful values from an incoming request (body,
@@ -29,23 +30,61 @@ func WithBinder(binder Binder) GatewayOption {
 }
 
 // jsonBinder is the default gateway binder that uses encoding/json to apply body/path/query data
-// to service request models.
+// to service request models. This unifies the processing so that all 3 sources of values are unmarshaled
+// using the same semantics. The goal is that whether a value comes in from the body or the path or the
+// query string, if you supplied a custom UnmarshalJSON() function for a type, that will work.
+//
+// It assumes that the body is JSON, naturally. The path and query params, however, get massaged into
+// JSON so that we can use the standard library's JSON package to unmarshal that data onto your out value.
+// For example, let's assume that we have the following query string:
+//
+//     ?first=Bob&last=Smith&age=39&address.city=Seattle&enabled=true
+//
+// The jsonBinder will first create 5 separate JSON objects:
+//
+//     { "first": "Bob" }
+//     { "last": "Smith" }
+//     { "age": 39 }
+//     { "address": { "city": "Seattle" } }     <-- notice how we handle nested values separated by "."
+//     { "enabled": true }
+//
+// After generating each value, the jsonBinder will feed the massaged JSON to a 'json.Decoder' and standard
+// JSON marshaling rules will overlay each one onto your 'out' value.
 type jsonBinder struct{}
 
+// jsonBindingContext carries our buffer/decoder context through all of the binding operations so
+// that all values can share resources (e.g. binding the path params can piggy back off of the
+// work of binding the query string).
+type jsonBindingContext struct {
+	buf     *bytes.Buffer
+	decoder *json.Decoder
+}
+
 func (b jsonBinder) Bind(req *http.Request, out interface{}) error {
-	if err := b.BindBody(req, out); err != nil {
+	// To keep the logic more simple (but fast enough for most use cases), we will generate a separate
+	// JSON representation of each value and run it through the JSON decoder. To make things a bit more
+	// efficient, we'll re-use the buffer/reader and the JSON decoder for each value we unmarshal
+	// on the output. This way we only suffer one buffer allocation no matter how many values we handle.
+	buf := &bytes.Buffer{}
+	ctx := jsonBindingContext{
+		buf:     buf,
+		decoder: json.NewDecoder(buf),
+	}
+
+	if err := b.BindBody(ctx, req, out); err != nil {
 		return fmt.Errorf("error binding body: %w", err)
 	}
-	if err := b.BindQueryString(req, out); err != nil {
+	if err := b.BindQueryString(ctx, req, out); err != nil {
 		return fmt.Errorf("error binding query string: %w", err)
 	}
-	if err := b.BindPathParams(req, out); err != nil {
+	if err := b.BindPathParams(ctx, req, out); err != nil {
 		return fmt.Errorf("error binding path params: %w", err)
 	}
 	return nil
 }
 
-func (b jsonBinder) BindBody(req *http.Request, out interface{}) error {
+// BindBody decodes the JSON body of the request onto the 'out' value.
+func (b jsonBinder) BindBody(_ jsonBindingContext, req *http.Request, out interface{}) error {
 	if req.Body == nil {
 		return nil
 	}
@@ -55,28 +94,31 @@ func (b jsonBinder) BindBody(req *http.Request, out interface{}) error {
 	return json.NewDecoder(req.Body).Decode(out)
 }
 
-func (b jsonBinder) BindQueryString(req *http.Request, out interface{}) error {
-	return b.bindValues(req.URL.Query(), out)
+// BindQueryString decodes all of the query string parameters onto the 'out' value. Each parameter will
+// be converted to an equivalent JSON object and unmarshaled separately.
+func (b jsonBinder) BindQueryString(ctx jsonBindingContext, req *http.Request, out interface{}) error {
+	if req.URL == nil {
+		return errors.BadRequest("request missing url")
+	}
+	return b.bindValues(ctx, req.URL.Query(), out)
 }
 
-func (b jsonBinder) BindPathParams(req *http.Request, out interface{}) error {
+// BindQueryString decodes all of the URL path parameters onto the 'out' value. Each parameter will
+// be converted to an equivalent JSON object and unmarshaled separately.
+func (b jsonBinder) BindPathParams(ctx jsonBindingContext, req *http.Request, out interface{}) error {
+	if req.Context() == nil {
+		return errors.BadRequest("request missing context")
+	}
 	params := httprouter.ParamsFromContext(req.Context())
 	values := url.Values{}
 	for _, param := range params {
 		values[param.Key] = []string{param.Value}
 	}
-	return b.bindValues(values, out)
+	return b.bindValues(ctx, values, out)
 }
 
-func (b jsonBinder) bindValues(requestValues url.Values, out interface{}) error {
+func (b jsonBinder) bindValues(ctx jsonBindingContext, requestValues url.Values, out interface{}) error {
 	outValue := reflect.Indirect(reflect.ValueOf(out))
-
-	// To keep the logic more simple (but fast enough for most use cases), we will generate a separate
-	// JSON representation of each value and run it through the JSON decoder. To make things a bit more
-	// efficient, we'll re-use the buffer/reader and the JSON decoder for each value we unmarshal
-	// ont the output.
-	buf := &bytes.Buffer{}
-	decoder := json.NewDecoder(buf)
 
 	for key, value := range requestValues {
 		keySegments := strings.Split(key, ".")
@@ -87,7 +129,7 @@ func (b jsonBinder) bindValues(requestValues url.Values, out interface{}) error 
 		// that will most naturally unmarshal to the Go type. So if the Go data type for the "baz" field
 		// is uint16 then we'd expect this to return 'jsonTypeNumber'. If "baz" were a string then
 		// we'd expect this to return 'jsonTypeString', and so on.
-		valueType := b.keyToJSONType(outValue, keySegments)
+		valueType := b.keyToJSONType(outValue, keySegments, value[0])
 
 		// We didn't find a field path with that name (e.g. the key was "name" but there was no field called "name")
 		if valueType == jsonTypeNil {
@@ -102,22 +144,22 @@ func (b jsonBinder) bindValues(requestValues url.Values, out interface{}) error 
 
 		// Convert the parameter "foo.bar.baz=4" into {"foo":{"bar":{"baz":4}}} so that the standard
 		// JSON decoder can work its magic to apply that to 'out' properly.
-		buf.Reset()
-		b.writeValueJSON(buf, keySegments, value[0], valueType)
+		ctx.buf.Reset()
+		b.writeParamJSON(ctx.buf, keySegments, value[0], valueType)
 
 		// Now that we have a close-enough JSON representation of your parameter, let the standard
 		// JSON decoder do its magic.
-		if err := decoder.Decode(out); err != nil {
+		if err := ctx.decoder.Decode(out); err != nil {
 			return fmt.Errorf("unable to bind value '%s'='%s': %w", key, value[0], err)
 		}
 	}
 	return nil
 }
 
-// writeValueJSON accepts the decomposed parameter key (e.g. "foo.bar.baz") and the raw string value (e.g. "moo")
+// writeParamJSON accepts the decomposed parameter key (e.g. "foo.bar.baz") and the raw string value (e.g. "moo")
 // and writes JSON to the buffer which can be used in standard JSON decoding/unmarshaling to apply the value
 // to the out object (e.g. `{"foo":{"bar":{"baz":"moo"}}}`).
-func (b jsonBinder) writeValueJSON(buf *bytes.Buffer, keySegments []string, value string, valueType jsonType) {
+func (b jsonBinder) writeParamJSON(buf *bytes.Buffer, keySegments []string, value string, valueType jsonType) {
 	for _, keySegment := range keySegments {
 		buf.WriteString(`{"`)
 		buf.WriteString(keySegment)
@@ -160,7 +202,11 @@ const (
 	jsonTypeArray  = jsonType(5)
 )
 
-func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string) jsonType {
+// keyToJSONType looks at your parameter key (e.g. "foo.bar.baz") and your value (e.g. "12345"), and
+// indicates how we should format the value when creating binding JSON. It will use reflection to
+// traverse the Go attributes foo, then bar, then baz, and return the most appropriate JSON type
+// for the go type. For instance if "baz" is a uint16, the most appropriate jsonType is jsonTypeNumber.
+func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string, value string) jsonType {
 	keyLength := len(key)
 	if keyLength < 1 {
 		return jsonTypeNil
@@ -169,35 +215,51 @@ func (b jsonBinder) keyToJSONType(outValue reflect.Value, key []string) jsonType
 		return jsonTypeNil
 	}
 
-	currentType := outValue.Type()
-	currentJSONType := jsonTypeObject
+	// Follow the path of attributes described by the key, so if the key was "foo.bar.baz" then look up
+	// "foo" on the out value, then the "bar" attribute on that type, then the "baz" attribute on that type.
+	// Once we exit the loop, 'actualType' should be the type of that nested "baz" field and we can
+	// determine the correct JSON type from there.
+	actualType := outValue.Type()
 	for i := 0; i < keyLength; i++ {
-		field, ok := reflection.FindField(currentType, key[i])
+		field, ok := reflection.FindField(actualType, key[i])
 		if !ok {
 			return jsonTypeNil
 		}
-
-		currentType = field.Type
-		currentJSONType = b.fieldToJSONType(field)
-
-		// There are more segments left in the key (e.g. we're only on "bar" of the key "foo.bar.baz.blah"),
-		// so update our cursor type so that we can continue to iterate deeper into the structure. If, however,
-		// the value is not a struct or map, we can't have attributes on it, so we've got a mismatch between
-		// the incoming data that thinks the structure is more rich than it is. In the example maybe "foo.bar"
-		// is actually a string when you look at the Go models, so we can't possibly resolve the
-		// attribute "baz" on a string.
-		finalSegment := i >= keyLength-1
-		if !finalSegment && currentJSONType != jsonTypeObject {
-			return jsonTypeNil
-		}
+		actualType = field.Type
 	}
-	return currentJSONType
+
+	// Now that we have the Go type for the field that will ultimately be populated by this parameter/value,
+	// we need to do a quick double check. The field's Go type might be some type alias for an int64 so the
+	// natural choice for a JSON binding would be to use a number (which is what 't' will resolve to).
+	//
+	// But... what if the user provided the value "5m2s" for that field? If we blindly treat the value like
+	// a number, we'll end up with JSON that looks like {"baz":5m2s} which is invalid. We need to quote that
+	// value for it to remain valid JSON. So you only get to be a number/boolean if your parameter's value
+	// looks like one of those values, too.
+	//
+	// The canonical use-case for this situation is if you define a custom type alias like this:
+	//
+	// type ISODuration int64
+	//
+	// You then implement the MarshalJSON() and UnmarshalJSON() functions so that it supports ISO duration formats
+	// such as "PT3M49S". By looking at the Go type you'd think that the incoming param value should be a
+	// JSON number (since the duration is an int64), but the value doesn't "look" like a number; it looks
+	// like a freeform string. As a result, we need to build the binding JSON {"foo":"PT3M49S"} since we will
+	// treat the right hand side as a string rather than {"foo":PT3M48S} which is not valid.
+	t := b.typeToJSONType(actualType)
+	if t == jsonTypeBool && !b.looksLikeBoolJSON(value) {
+		return jsonTypeString
+	}
+	if t == jsonTypeNumber && !b.looksLikeNumberJSON(value) {
+		return jsonTypeString
+	}
+	return t
 }
 
 // fieldToJSONType looks at the Go type of some field on a struct and returns the JSON data type
 // that will most likely unmarshal to that field w/o an error.
-func (b jsonBinder) fieldToJSONType(field reflect.StructField) jsonType {
-	switch field.Type.Kind() {
+func (b jsonBinder) typeToJSONType(actualType reflect.Type) jsonType {
+	switch actualType.Kind() {
 	case reflect.String:
 		return jsonTypeString
 	case reflect.Bool:
@@ -215,4 +277,26 @@ func (b jsonBinder) fieldToJSONType(field reflect.StructField) jsonType {
 	default:
 		return jsonTypeNil
 	}
+}
+
+// looksLikeBoolJSON determines if the raw parameter value looks like a boolean value (i.e. true/false).
+func (b jsonBinder) looksLikeBoolJSON(value string) bool {
+	value = strings.ToLower(value)
+	return value == "true" || value == "false"
+}
+
+// looksLikeNumberJSON determines if the raw parameter value looks like it can be formatted as a JSON
+// number. Basically, does it only contain digits and a decimal point. Currently this only supports using
+// periods as decimal points. A future iteration might support using /x/text/language to support commas
+// as decimals points.
+func (b jsonBinder) looksLikeNumberJSON(value string) bool {
+	for _, r := range value {
+		if r == '.' {
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/rpc/binding_test.go
+++ b/rpc/binding_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkJsonBinder_Bind(b *testing.B) {
 	b.ReportAllocs()
 	binder := jsonBinder{}
-	address, _ := url.Parse("http://localhost:8080/group/abcdef?flaggeroo=true&page.limit=42&p.offset=3&p.order=crap&p.missing=goo")
+	address, _ := url.Parse("http://localhost:8080/group/abcdef?flaggeroo=true&p.limit=42&p.offset=3&p.order=crap&p.missing=goo")
 	request := &http.Request{
 		URL: address,
 	}

--- a/rpc/binding_test.go
+++ b/rpc/binding_test.go
@@ -1,0 +1,44 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func BenchmarkJsonBinder_Bind(b *testing.B) {
+	b.ReportAllocs()
+	binder := jsonBinder{}
+	address, _ := url.Parse("http://localhost:8080/group/abcdef?flag=true&page.limit=42&page.offset=3&page.sort=crap&page.missing=goo")
+	request := &http.Request{
+		URL: address,
+	}
+	params := httprouter.Params{
+		httprouter.Param{Key: "id", Value: "abcdef"},
+	}
+	request = request.WithContext(context.WithValue(context.Background(), httprouter.ParamsKey, params))
+	output := benchmarkRequest{}
+	for i := 0; i < b.N; i++ {
+		_ = binder.Bind(request, &output)
+	}
+	fmt.Printf(">>>> %+v\n", output)
+}
+
+type benchmarkRequest struct {
+	ID   string           `json:"id"`
+	Flag bool             `json:"flag"`
+	Flip benchmarkFlipper `json:"flip"`
+	Page benchmarkPaging  `json:"page"`
+}
+
+type benchmarkFlipper bool
+
+type benchmarkPaging struct {
+	Limit  int
+	Offset int
+	Sort   string
+}

--- a/rpc/binding_test.go
+++ b/rpc/binding_test.go
@@ -13,7 +13,7 @@ import (
 func BenchmarkJsonBinder_Bind(b *testing.B) {
 	b.ReportAllocs()
 	binder := jsonBinder{}
-	address, _ := url.Parse("http://localhost:8080/group/abcdef?flag=true&page.limit=42&page.offset=3&page.sort=crap&page.missing=goo")
+	address, _ := url.Parse("http://localhost:8080/group/abcdef?flaggeroo=true&page.limit=42&p.offset=3&p.order=crap&p.missing=goo")
 	request := &http.Request{
 		URL: address,
 	}
@@ -30,9 +30,9 @@ func BenchmarkJsonBinder_Bind(b *testing.B) {
 
 type benchmarkRequest struct {
 	ID   string           `json:"id"`
-	Flag bool             `json:"flag"`
+	Flag bool             `json:"flaggeroo"`
 	Flip benchmarkFlipper `json:"flip"`
-	Page benchmarkPaging  `json:"page"`
+	Page benchmarkPaging  `json:"p"`
 }
 
 type benchmarkFlipper bool
@@ -40,5 +40,5 @@ type benchmarkFlipper bool
 type benchmarkPaging struct {
 	Limit  int
 	Offset int
-	Sort   string
+	Sort   string `json:"order"`
 }

--- a/rpc/middleware.go
+++ b/rpc/middleware.go
@@ -30,7 +30,7 @@ type Middleware interface {
 	ServeHTTP(w http.ResponseWriter, req *http.Request, next http.HandlerFunc)
 }
 
-// Middleware is a component that conforms to the 'negroni' middleware function. It accepts the
+// MiddlewareFunc is a component that conforms to the 'negroni' middleware function. It accepts the
 // standard HTTP inputs as well as the rest of the computation.
 type MiddlewareFunc func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc)
 


### PR DESCRIPTION
Completely rewrote the `rpc.jsonBinder` with the following improvements:

* Utilizes both the format of the param value AND the Go type of the unmarshaled field to figure out how to format it as JSON. This fixes the issue where "999" was always treated as a number; even when the output field was a string.
* Supports nested path/query parameters. The parameter `criteria.paging.limit=15` will now recursively bind `criteria`, them `paging`, then set the`limit`to 15 as opposed to literally looking for a field on the 'out' value called 'criteria.paging.limit'.
* Much more efficient. I added a binding context that lets the binder re-use buffers/decoders so we only take an allocation hit on the first bound value. This cut the number of allocations in half and the allocation size by about 500%.