### PR TITLE
Refactor: parser functions don't side-effect Context

### DIFF
--- a/example/cmd/main.go
+++ b/example/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 		rpc.WithPrefix("v2"),
 	)
 
-	//go runClientTest()
+	go runClientTest()
 	fmt.Println("[SERVER] Running on :8080")
 	http.ListenAndServe(":8080", gw)
 }

--- a/parser/context.go
+++ b/parser/context.go
@@ -27,21 +27,6 @@ type Context struct {
 	Services []*ServiceDeclaration
 	// Models encapsulates snapshot info for all service request/response structs that were defined in the input file.
 	Models []*ServiceModelDeclaration
-
-	// currentService is used internally when processing method info to know what service you're "inside" of.
-	currentService *ServiceDeclaration
-	// currentMethod is used internally when processing field info to know what service operation you're "inside" of.
-	currentMethod *ServiceMethodDeclaration
-}
-
-// AddService appends a service definition to this parsing context.
-func (ctx *Context) AddService(service *ServiceDeclaration) {
-	ctx.Services = append(ctx.Services, service)
-}
-
-// AddModel appends a request/response struct definition to this parsing context.
-func (ctx *Context) AddModel(model *ServiceModelDeclaration) {
-	ctx.Models = append(ctx.Models, model)
 }
 
 // ModelByName looks through "Models" to find the one whose method/function name matches 'name'.


### PR DESCRIPTION
Originally, the `parser.ParseXXX()` functions were a mish-mash of styles. Some mutated the `Context` (e.g. `ParseService` called `ctx.AddService()`) while others returned the value they parsed. I standardized the style so that everything returns a new instance of the `ServiceXxxDeclaration` but doesn't modify the incoming `Context` at all; the callers will need to add the resulting value(s) to the context themselves. Aside from making the code easier to reason about, it will improve testability when I get around to bulking up the suite.