### PR TITLE
CLI update: `frodo create`

### DIFF
--- a/generate/service.go
+++ b/generate/service.go
@@ -1,0 +1,133 @@
+package generate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+// ServiceScaffold creates the bare minimum code required to have a frodo-powered service. It
+// creates a directory for the service code to live, a declaration file that contains the
+// interface and model definitions, and a skeleton implementation. These all help establish some
+// of the base patterns you should use when working with frodo services.
+func ServiceScaffold(serviceName string, path string) error {
+	shortName := serviceName
+	shortName = strings.TrimSuffix(shortName, "Service")
+	shortName = strings.TrimSuffix(shortName, "service")
+
+	shortNameLower := strings.ToLower(shortName)
+	shortNameTitle := strings.Title(shortName)
+
+	ctx := scaffoldServiceContext{
+		RawName:        serviceName,
+		ShortName:      shortNameTitle,
+		ShortNameLower: shortNameLower,
+		InterfaceName:  shortNameTitle + "Service",
+		HandlerName:    shortNameTitle + "ServiceHandler",
+		Path:           path,
+	}
+
+	if path == "" {
+		ctx.Path = ctx.ShortNameLower
+	}
+	ctx.Package = filepath.Base(ctx.Path)
+
+	if err := scaffoldDirectory(ctx); err != nil {
+		return err
+	}
+	if err := scaffoldTemplate(ctx, serviceDeclarationTemplate); err != nil {
+		return err
+	}
+	if err := scaffoldTemplate(ctx, serviceHandlerTemplate); err != nil {
+		return err
+	}
+	return nil
+}
+
+func scaffoldDirectory(ctx scaffoldServiceContext) error {
+	dirInfo, err := os.Stat(ctx.Path)
+	if os.IsNotExist(err) {
+		return os.MkdirAll(ctx.Path, 0777)
+	}
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("unable to create service: '%s' is not a directory", ctx.Path)
+	}
+	return nil
+}
+
+func scaffoldTemplate(ctx scaffoldServiceContext, t *template.Template) error {
+	path := filepath.Join(ctx.Path, ctx.ShortNameLower+t.Name())
+
+	_ = os.Remove(path)
+	outputFile, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("unable to open file: %s: %w", path, err)
+	}
+	defer outputFile.Close()
+
+	err = t.Execute(outputFile, ctx)
+	if err != nil {
+		return fmt.Errorf("unable to eval code template: %s: %w", path, err)
+	}
+	return nil
+}
+
+type scaffoldServiceContext struct {
+	// RawName is the exact input that the user provided when invoking the scaffolding command.
+	RawName string
+	// ShortNameLower is the name of the service w/o the "Service" suffix (e.g. "Greeter")
+	ShortName string
+	// ShortNameLower is the name of the service w/o the "Service" suffix in all lower case (e.g. "greeter")
+	ShortNameLower string
+	// InterfaceName is the "cleaned up" version used for the service interface (e.g. "GreeterService")
+	InterfaceName string
+	// HandlerName is the name of the struct for the real implementation (e.g. "GreeterServiceHandler")
+	HandlerName string
+	// Path is the directory where we will put the declaration file for the service.
+	Path string
+	// Package is the name of the package that the new service will belong to.
+	Package string
+}
+
+var serviceDeclarationTemplate = parseArtifactTemplate("service.go", `package {{ .Package }}
+
+import (
+	"context"
+)
+
+// {{ .InterfaceName }} is a service that...
+type {{ .InterfaceName }} interface  {
+    // Lookup fetches a {{ .ShortName }} record by its unique identifier. 
+	Lookup(context.Context, *LookupRequest) (*LookupResponse, error)
+}
+
+type LookupRequest struct {
+	ID string
+}
+
+type LookupResponse struct {
+	ID   string
+	Name string
+}
+`)
+
+var serviceHandlerTemplate = parseArtifactTemplate("service_handler.go", `package {{ .Package }}
+
+import (
+	"context"
+
+	"github.com/robsignorelli/frodo/rpc/errors"
+)
+
+// {{ .HandlerName }} implements all of the "real" functionality for the {{ .InterfaceName }}.
+type {{ .InterfaceName }}Handler struct{}
+
+func (svc *{{ .HandlerName }}) Lookup(ctx context.Context, request *LookupRequest) (*LookupResponse, error) {
+	if request.ID == "" {
+		return nil, errors.BadRequest("lookup: id is required")
+	}
+	return &LookupResponse{ID: request.ID, Name: "Beetlejuice"}, nil
+}
+`)

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ func main() {
 	}
 	rootCmd.AddCommand(GatewayCommand{}.Cobra())
 	rootCmd.AddCommand(ClientCommand{}.Cobra())
+	rootCmd.AddCommand(CreateCommand{}.Cobra())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -44,7 +45,7 @@ func (c GatewayCommand) Cobra() *cobra.Command {
 // Run handles when the user actually executes 'frodo gateway'; generating a Go-based gateway
 // type that can be fed to http.ListenAndServe() in order to expose a service over RPC.
 func (c GatewayCommand) Run(cmd *cobra.Command, _ []string) error {
-	inputFileName := cmd.Flags().Lookup("input").Value.String()
+	inputFileName := cmd.Flag("input").Value.String()
 	return generateArtifact(inputFileName, generate.TemplateGatewayGo)
 }
 
@@ -69,8 +70,8 @@ func (c ClientCommand) Cobra() *cobra.Command {
 // Run handles when the user executes 'frodo client'; generating a strongly typed RPC client that
 // accepts/returns data structures, but handles all of the HTTP/RPC magic under the hood.
 func (c ClientCommand) Run(cmd *cobra.Command, _ []string) error {
-	inputFileName := cmd.Flags().Lookup("input").Value.String()
-	lang := cmd.Flags().Lookup("language").Value.String()
+	inputFileName := cmd.Flag("input").Value.String()
+	lang := cmd.Flag("language").Value.String()
 	switch strings.ToLower(lang) {
 	case "go":
 		return generateArtifact(inputFileName, generate.TemplateClientGo)
@@ -97,4 +98,30 @@ func generateArtifact(inputFileName string, artifactTemplate *template.Template)
 	}
 
 	return nil
+}
+
+// CreateCommand is the scaffolding command that creates a new service directory and a minimal
+// template Go declaration file w/ your service and some sample operations.
+type CreateCommand struct{}
+
+// Cobra creates the Cobra struct describing this CLI command and its options.
+func (c CreateCommand) Cobra() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:  "create",
+		Args: cobra.MaximumNArgs(0),
+		RunE: c.Run,
+	}
+	cmd.Flags().StringP("service", "s", "", "The name of the service to create (doesn't have to end in 'Service')")
+	cmd.Flags().StringP("dir", "d", "", "Path to the directory where we'll write the Go file (defaults to new directory named after the service)")
+
+	_ = cmd.MarkFlagRequired("service")
+	return cmd
+}
+
+// Run handles when the user executes 'frodo create'; scaffolding a new service directory/declaration.
+func (c CreateCommand) Run(cmd *cobra.Command, _ []string) error {
+	return generate.ServiceScaffold(
+		cmd.Flag("service").Value.String(),
+		cmd.Flag("dir").Value.String(),
+	)
 }

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func (c CreateCommand) Cobra() *cobra.Command {
 	}
 	cmd.Flags().StringP("service", "s", "", "The name of the service to create (doesn't have to end in 'Service')")
 	cmd.Flags().StringP("dir", "d", "", "Path to the directory where we'll write the Go file (defaults to new directory named after the service)")
+	cmd.Flags().BoolP("force", "f", false, "Overwrite declaration/handler source code files if they exist. (default=false)")
 
 	_ = cmd.MarkFlagRequired("service")
 	return cmd
@@ -120,8 +121,9 @@ func (c CreateCommand) Cobra() *cobra.Command {
 
 // Run handles when the user executes 'frodo create'; scaffolding a new service directory/declaration.
 func (c CreateCommand) Run(cmd *cobra.Command, _ []string) error {
-	return generate.ServiceScaffold(
-		cmd.Flag("service").Value.String(),
-		cmd.Flag("dir").Value.String(),
-	)
+	return generate.ServiceScaffold(generate.ServiceScaffoldRequest{
+		ServiceName: cmd.Flag("service").Value.String(),
+		Directory:   cmd.Flag("dir").Value.String(),
+		Force:       cmd.Flag("force").Value.String() == "true",
+	})
 }

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -365,9 +365,8 @@ func IsServiceDeclaration(astObj *ast.Object) bool {
 		return false
 	}
 
-	// We're enforcing the convention that the "foo" service is called "FooService" or "FooSvc"
-	name := astObj.Name
-	return strings.HasSuffix(name, "Service") || strings.HasSuffix(name, "Svc")
+	// We're enforcing the convention that the "foo" service is called "FooService"
+	return strings.HasSuffix(astObj.Name, "Service")
 }
 
 // IsModelDeclaration looks at a node from your file's AST and returns true if it's a type


### PR DESCRIPTION
Added another sub-command to the `frodo` executable that scaffolds a new service for you that conforms to the best practices that we want to enforce:

```shell
frodo create --service=user --dir=./users
```

This will create the directory/package `users` and then write the following files:

* `user_service.go`: contains the service interface and request/response structs
* `user_service_handler.go`: contains the struct that implements the "real" service implementation

The `--dir` is optional, so it will default to creating a directory with the same name as the service. Additionally, the operation will fail if the .go files already exist unless you also include the `--force` flag.