### PR TITLE
Tightened up CLI commands to use positional args.

### DIFF
--- a/cli/generate_client.go
+++ b/cli/generate_client.go
@@ -26,16 +26,15 @@ type GenerateClient struct{}
 func (c GenerateClient) Command() *cobra.Command {
 	request := &GenerateClientRequest{}
 	cmd := &cobra.Command{
-		Use:  "client",
-		Args: cobra.MaximumNArgs(0),
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Use:   "client [flags] FILENAME",
+		Short: "Process a Go source file with your service interface to generate an RPC client proxy for your service(s).",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			request.InputFileName = args[0]
 			return c.Exec(request)
 		},
 	}
-	cmd.Flags().StringVar(&request.InputFileName, "input", "", "Path to the Go file w/ your service interface.")
-	cmd.Flags().StringVar(&request.Language, "language", "go", "The file extension for the language to output (e.g. 'go' or 'js')")
-
-	_ = cmd.MarkFlagRequired("input")
+	cmd.Flags().StringVar(&request.Language, "language", "go", "The file extension of the target language (e.g. 'go' or 'js')")
 	return cmd
 }
 

--- a/cli/generate_gateway.go
+++ b/cli/generate_gateway.go
@@ -21,14 +21,14 @@ type GenerateGateway struct{}
 func (c GenerateGateway) Command() *cobra.Command {
 	request := &GenerateGatewayRequest{}
 	cmd := &cobra.Command{
-		Use:  "gateway",
-		Args: cobra.MaximumNArgs(0),
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Use:   "gateway [flags] FILENAME",
+		Short: "Process a Go source file with your service interface to generate an RPC/API gateway.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			request.InputFileName = args[0]
 			return c.Exec(request)
 		},
 	}
-	cmd.Flags().StringVar(&request.InputFileName, "input", "", "Path to the Go file w/ your service interface.")
-	_ = cmd.MarkFlagRequired("input")
 	return cmd
 }
 

--- a/example/posts/gen/post_service.gen.gateway.go
+++ b/example/posts/gen/post_service.gen.gateway.go
@@ -1,5 +1,5 @@
 // !!!!!!! DO NOT EDIT !!!!!!!
-// Auto-generated server code from post_service.go
+// Auto-generated server code from example/posts/post_service.go
 // !!!!!!! DO NOT EDIT !!!!!!!
 package postsrpc
 


### PR DESCRIPTION
Instead of requiring a named arg like `--input` in the CLI, I switched it up to use positional arguments so the examples for how to use it are much more simple:

```
# BEFORE
frodo gateway --input=users/user_service.go
# AFTER
frodo gateway users/user_service.go
```

I also made it so that you can specify a custom port when you generate a new service using `frodo create`.