### PR TITLE
Expanded documentation parsing to services/models

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ this work done; just which operations are available.
 We actually have enough for `frodo` to
 generate your RPC/API code already, but we'll hold off
 for a moment. Frodo frees you up to focus on building
-features, so let's actually implement service.
+features, so let's actually implement service; no networking,
+no marshaling, no status stuff, just logic to make your
+service behave properly.
 
 ```go
 // calculator_service_handler.go
@@ -346,23 +348,19 @@ func (svc VideoServiceHandler) Download(ctx context.Context, req *DownloadReques
 ## API Versioning
 
 You can prepend a version or any sort of domain prefix to
-every URL in your API by using the `WithPrefix` functional
-parameter when building your gateway. Just remember to include
-that in the base URL when building clients for that service.
+every URL in your service's API by using the `PATH` doc option on your
+service interface.
 ```go
-import (
-    "github.com/robsignorelli/frodo/rpc"
-)
-
-// ...
-gateway := calcrpc.NewCalculatorServiceGateway(service,
-    rpc.WithPrefix("v2"),
-)
-// ...
-client := calcrpc.NewCalculatorServiceClient("http://localhost:9000/v2")
+// CalculatorService provides some basic arithmetic operations.
+//
+// PATH /v2
+type CalculatorService interface {
+    Add(context.Context, *AddRequest) (*AddResponse, error)
+    Sub(context.Context, *SubRequest) (*SubResponse, error)
+}
 ```
 
-Your API and RPC communication will use the "v2" prefix under the
+Your API and RPC clients will be auto-wired to use the "v2" prefix under the
 hood, but if you want to hit the raw HTTP endpoints, here's
 how they look now:
 

--- a/README.md
+++ b/README.md
@@ -382,8 +382,8 @@ example using [github.com/urfave/negroni](https://github.com/urfave/negroni)
 func main() {
     service := calc.CalculatorServiceHandler{}
     gateway := calcrpc.NewCalculatorServiceGateway(service,
-        rpc.WithMiddleware(
-            negroni.NewLogger(),
+        rpc.WithMiddlewareFunc(
+            negroni.NewLogger().ServeHTTP,
             NotOnMonday,
         ))
 
@@ -392,7 +392,7 @@ func main() {
 
 func NotOnMonday(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
     if time.Now().Weekday() == time.Monday {
-        http.Error(w, "no math on monday", 403)
+        http.Error(w, "garfield says no math on mondays", 403)
         return
     }
     next(w, req)

--- a/cli/generate_client.go
+++ b/cli/generate_client.go
@@ -43,7 +43,7 @@ func (c GenerateClient) Exec(request *GenerateClientRequest) error {
 	switch strings.ToLower(request.Language) {
 	case "go", "":
 		return c.generate(request, generate.TemplateClientGo)
-	case "js":
+	case "js", "javascript", "node", "nodejs":
 		return c.generate(request, generate.TemplateClientJS)
 	default:
 		return fmt.Errorf("unsupported client language")

--- a/example/comments/gen/comment_service.gen.client.go
+++ b/example/comments/gen/comment_service.gen.client.go
@@ -14,14 +14,12 @@ import (
 // NewCommentServiceClient creates an RPC client that conforms to the CommentService interface, but delegates
 // work to remote instances. You must supply the base address of the remote service gateway instance or
 // the load balancer for that service.
-//
-// You should be able to get a working service using default options (i.e. no options), but you can customize
-// the HTTP client, define middleware, and more using client options. All of the ones that apply to the RPC
-// client are named "WithClientXXX()".
+// CommentService manages reader-submitted comments to posts. It's where horrible people get
+// to spew their vitriol all over the internet and humanity dies a little.
 func NewCommentServiceClient(address string, options ...rpc.ClientOption) *CommentServiceClient {
-	return &CommentServiceClient{
-		Client: rpc.NewClient("CommentService", address, options...),
-	}
+	rpcClient := rpc.NewClient("CommentService", address, options...)
+	rpcClient.PathPrefix = ""
+	return &CommentServiceClient{Client: rpcClient}
 }
 
 // CommentServiceClient manages all interaction w/ a remote CommentService instance by letting you invoke functions
@@ -31,6 +29,7 @@ type CommentServiceClient struct {
 	rpc.Client
 }
 
+// CreateComment adds a comment to a post w/ the given details.
 func (client *CommentServiceClient) CreateComment(ctx context.Context, request *comments.CreateCommentRequest) (*comments.CreateCommentResponse, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("precondition failed: nil context")
@@ -44,6 +43,7 @@ func (client *CommentServiceClient) CreateComment(ctx context.Context, request *
 	return response, err
 }
 
+// FindByPost lists all comments submitted to the given post.
 func (client *CommentServiceClient) FindByPost(ctx context.Context, request *comments.FindByPostRequest) (*comments.FindByPostResponse, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("precondition failed: nil context")

--- a/example/comments/gen/comment_service.gen.gateway.go
+++ b/example/comments/gen/comment_service.gen.gateway.go
@@ -25,6 +25,7 @@ import (
 func NewCommentServiceGateway(service comments.CommentService, options ...rpc.GatewayOption) rpc.Gateway {
 	gw := rpc.NewGateway(options...)
 	gw.Name = "CommentService"
+	gw.PathPrefix = ""
 
 	gw.Register(rpc.Endpoint{
 		Method:      "POST",

--- a/example/comments/makefile
+++ b/example/comments/makefile
@@ -2,8 +2,8 @@ run: build
 	out/comment-service
 
 frodo:
-	frodo gateway --input=comment_service.go && \
-	frodo client  --input=comment_service.go
+	../../out/frodo gateway comment_service.go && \
+	../../out/frodo client  comment_service.go
 
 build: frodo
 	go build -o out/comment-service cmd/main.go

--- a/example/posts/cmd/main.go
+++ b/example/posts/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/robsignorelli/frodo/example/posts"
@@ -9,6 +10,25 @@ import (
 
 func main() {
 	postService := posts.PostServiceHandler{}
-	gateway := postsrpc.NewPostServiceGateway(&postService)
+	gateway := postsrpc.NewPostServiceGateway(&postService) //rpc.WithMiddleware(cors.AllowAll())
+
 	http.ListenAndServe(":9001", gateway)
+}
+
+func Echo(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	fmt.Println("Handling: 1A", req.Method, req.URL)
+	next(w, req)
+	fmt.Println("Handling: 1B", req.Method, req.URL)
+}
+
+func Echo2(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	fmt.Println("Handling: 2A", req.Method, req.URL)
+	next(w, req)
+	fmt.Println("Handling: 2B", req.Method, req.URL)
+}
+
+func Echo3(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+	fmt.Println("Handling: 3A", req.Method, req.URL)
+	next(w, req)
+	fmt.Println("Handling: 3B", req.Method, req.URL)
 }

--- a/example/posts/cmd/main.go
+++ b/example/posts/cmd/main.go
@@ -10,8 +10,7 @@ import (
 
 func main() {
 	postService := posts.PostServiceHandler{}
-	gateway := postsrpc.NewPostServiceGateway(&postService) //rpc.WithMiddleware(cors.AllowAll())
-
+	gateway := postsrpc.NewPostServiceGateway(&postService)
 	http.ListenAndServe(":9001", gateway)
 }
 

--- a/example/posts/gen/post_service.gen.client.go
+++ b/example/posts/gen/post_service.gen.client.go
@@ -14,14 +14,13 @@ import (
 // NewPostServiceClient creates an RPC client that conforms to the PostService interface, but delegates
 // work to remote instances. You must supply the base address of the remote service gateway instance or
 // the load balancer for that service.
-//
-// You should be able to get a working service using default options (i.e. no options), but you can customize
-// the HTTP client, define middleware, and more using client options. All of the ones that apply to the RPC
-// client are named "WithClientXXX()".
+// PostService is a service that manages blog/article posts. This is just for example purposes,
+// so this is not a truly exhaustive set of operations that you might want if you were *really*
+// building some sort of blog/CRM engine.
 func NewPostServiceClient(address string, options ...rpc.ClientOption) *PostServiceClient {
-	return &PostServiceClient{
-		Client: rpc.NewClient("PostService", address, options...),
-	}
+	rpcClient := rpc.NewClient("PostService", address, options...)
+	rpcClient.PathPrefix = "v2"
+	return &PostServiceClient{Client: rpcClient}
 }
 
 // PostServiceClient manages all interaction w/ a remote PostService instance by letting you invoke functions

--- a/example/posts/gen/post_service.gen.gateway.go
+++ b/example/posts/gen/post_service.gen.gateway.go
@@ -1,5 +1,5 @@
 // !!!!!!! DO NOT EDIT !!!!!!!
-// Auto-generated server code from example/posts/post_service.go
+// Auto-generated server code from post_service.go
 // !!!!!!! DO NOT EDIT !!!!!!!
 package postsrpc
 
@@ -25,6 +25,7 @@ import (
 func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOption) rpc.Gateway {
 	gw := rpc.NewGateway(options...)
 	gw.Name = "PostService"
+	gw.PathPrefix = "v2"
 
 	gw.Register(rpc.Endpoint{
 		Method:      "POST",
@@ -41,7 +42,7 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 			}
 
 			serviceResponse, err := service.GetPost(req.Context(), &serviceRequest)
-			response.Reply(200, serviceResponse, err)
+			response.Reply(202, serviceResponse, err)
 		},
 	})
 

--- a/example/posts/gen/post_service.gen.gateway.go
+++ b/example/posts/gen/post_service.gen.gateway.go
@@ -42,7 +42,7 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 			}
 
 			serviceResponse, err := service.GetPost(req.Context(), &serviceRequest)
-			response.Reply(202, serviceResponse, err)
+			response.Reply(200, serviceResponse, err)
 		},
 	})
 

--- a/example/posts/makefile
+++ b/example/posts/makefile
@@ -2,8 +2,8 @@ run: build
 	out/post-service
 
 frodo:
-	frodo gateway --input=post_service.go && \
-	frodo client  --input=post_service.go
+	../../out/frodo gateway post_service.go && \
+	../../out/frodo client  post_service.go
 
 build: frodo
 	go build -o out/post-service cmd/main.go

--- a/example/posts/post_service.go
+++ b/example/posts/post_service.go
@@ -8,6 +8,8 @@ import (
 // PostService is a service that manages blog/article posts. This is just for example purposes,
 // so this is not a truly exhaustive set of operations that you might want if you were *really*
 // building some sort of blog/CRM engine.
+//
+// PATH /v2
 type PostService interface {
 	// GetPost fetches a Post record by its unique identifier.
 	GetPost(context.Context, *GetPostRequest) (*GetPostResponse, error)
@@ -29,6 +31,7 @@ type GetPostRequest struct {
 	ID string
 }
 
+// GetPostResponse describes a single post in the blog.
 type GetPostResponse Post
 
 type CreatePostRequest struct {

--- a/generate/client.go
+++ b/generate/client.go
@@ -20,15 +20,12 @@ import (
 {{ range .Services }}
 // New{{ .Name }}Client creates an RPC client that conforms to the {{ .Name }} interface, but delegates
 // work to remote instances. You must supply the base address of the remote service gateway instance or
-// the load balancer for that service.
-//
-// You should be able to get a working service using default options (i.e. no options), but you can customize
-// the HTTP client, define middleware, and more using client options. All of the ones that apply to the RPC
-// client are named "WithClientXXX()".
+// the load balancer for that service. {{ range .Documentation }}
+// {{ . }}{{end}}
 func New{{ .Name }}Client(address string, options ...rpc.ClientOption) *{{ .Name }}Client {
-	return &{{ .Name }}Client{
-		Client: rpc.NewClient("{{ .Name }}", address, options...),
-	}
+	rpcClient := rpc.NewClient("{{ .Name }}", address, options...)
+	rpcClient.PathPrefix = "{{ .HTTPPathPrefix }}"
+	return &{{ .Name }}Client{Client: rpcClient} 
 }
 
 // {{ .Name }}Client manages all interaction w/ a remote {{ .Name }} instance by letting you invoke functions

--- a/generate/gateway.go
+++ b/generate/gateway.go
@@ -30,6 +30,7 @@ import (
 func New{{ .Name }}Gateway(service {{ $ctx.Package.Name }}.{{ .Name }}, options ...rpc.GatewayOption) rpc.Gateway {
 	gw := rpc.NewGateway(options...)
 	gw.Name = "{{ .Name }}"
+	gw.PathPrefix = "{{ .HTTPPathPrefix }}"
 
 	{{ $service := . }}
 	{{ range $service.Methods }}

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -11,14 +11,15 @@ const defaultFetch = fetch.bind(window);
 
 {{ range $service := .Services }}/**
  * Exposes all of the standard operations for the remote {{ .Name }} service. These RPC calls will be
- * sent over http(s) to the backend service instances. 
+ * sent over http(s) to the backend service instances. {{ range .Documentation }}
+ * {{ . }}{{end}}
  */
 class {{ .Name }}Client {
     _baseURL;
     _fetch;
 
-    constructor(baseURL, {pathPrefix, fetch} = {}) {
-        this._baseURL = trimSlashes(trimSlashes(baseURL) + '/' + trimSlashes(pathPrefix));
+    constructor(baseURL, {fetch} = {}) {
+        this._baseURL = trimSlashes(trimSlashes(baseURL) + '/' + trimSlashes('{{ .HTTPPathPrefix}}'));
         this._fetch = fetch || defaultFetch;
     }
 
@@ -169,7 +170,8 @@ function trimSlashes(value) {
 }
 
 {{ range .Models }}
-/**
+/** {{ range .Documentation }}
+ * {{ . }}{{ end }}
  * @typedef {Object|*} {{ .Name }}
  */
 {{ end }}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.15
 require (
 	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
 	github.com/robsignorelli/respond v0.2.0
-	github.com/rs/cors v1.7.0 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
 	github.com/robsignorelli/respond v0.2.0
+	github.com/rs/cors v1.7.0 // indirect
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/robsignorelli/respond v0.2.0 h1:m7gLgcXNtFIGG2rNNm6WRB/5YpqKsTjruA79K
 github.com/robsignorelli/respond v0.2.0/go.mod h1:L4c6fnzgdDO6rTkCTXNd4VU4wwDdjhdNo3oIA0BqxaI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/go.sum
+++ b/go.sum
@@ -97,16 +97,16 @@ github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCV
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a h1:VTF3sHLbpm2PdWMPKVWUMwKg85VE7Ep7wgBw8ETYri8=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -145,8 +145,6 @@ github.com/robsignorelli/respond v0.2.0 h1:m7gLgcXNtFIGG2rNNm6WRB/5YpqKsTjruA79K
 github.com/robsignorelli/respond v0.2.0/go.mod h1:L4c6fnzgdDO6rTkCTXNd4VU4wwDdjhdNo3oIA0BqxaI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
-github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -292,6 +290,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -359,6 +359,10 @@ func IsModelDeclaration(astObj *ast.Object) bool {
 	}
 }
 
+// ApplyDocumentation runs GoDoc parsing on your context's file and adds all of your source's documentation
+// comments to the services/methods/models in the context. This *does* mutate the values on the context.
+// In addition to regurgitating the comments, this will ultimately parse all of the Doc Options
+// that might appear in the comments.
 func ApplyDocumentation(ctx *Context) error {
 	docs, err := doc.NewFromFiles(ctx.FileSet, []*ast.File{ctx.File}, ctx.Module.Name)
 	if err != nil {
@@ -410,6 +414,8 @@ func ApplyDocumentation(ctx *Context) error {
 	return nil
 }
 
+// ApplyServiceDocumentation takes the documentation comment block above your interface type
+// declaration and applies them to the service snapshot, parsing all Doc Options in the process.
 func ApplyServiceDocumentation(_ *Context, service *ServiceDeclaration, comments string) {
 	if service == nil {
 		return
@@ -430,6 +436,8 @@ func ApplyServiceDocumentation(_ *Context, service *ServiceDeclaration, comments
 	service.Documentation = service.Documentation.Trim()
 }
 
+// ApplyMethodDocumentation takes the documentation comment block above your interface function
+// declaration and applies them to the method snapshot, parsing all Doc Options in the process.
 func ApplyMethodDocumentation(_ *Context, method *ServiceMethodDeclaration, comments string) {
 	if method == nil {
 		return
@@ -469,6 +477,8 @@ func ApplyMethodDocumentation(_ *Context, method *ServiceMethodDeclaration, comm
 	method.Documentation = method.Documentation.Trim()
 }
 
+// ApplyModelDocumentation takes the documentation comment block above your struct/alias type
+// declaration and applies them to the model snapshot, parsing all Doc Options in the process.
 func ApplyModelDocumentation(_ *Context, model *ServiceModelDeclaration, comments string) {
 	if model == nil {
 		return

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -445,6 +445,12 @@ func ApplyMethodDocumentation(_ *Context, method *ServiceMethodDeclaration, comm
 	if comments == "" {
 		return
 	}
+	// Notice that "OPTIONS /" is not one of the cases. That's by design. When the gateway
+	// registers your POST operation (or whatever method), we're actually going to register
+	// that method AND an OPTIONS route for you. By default, the OPTIONS route will simply
+	// reject the request (i.e. no default CORS). If bring your own CORS middleware to the
+	// party it will respond affirmatively before the rejection. There's more info in the
+	// comments of gateway.New() that describes why we need this limitation for now.
 	for _, line := range strings.Split(comments, "\n") {
 		switch {
 		case strings.HasPrefix(line, "GET /"):
@@ -462,9 +468,6 @@ func ApplyMethodDocumentation(_ *Context, method *ServiceMethodDeclaration, comm
 		case strings.HasPrefix(line, "DELETE /"):
 			method.HTTPMethod = http.MethodDelete
 			method.HTTPPath = normalizePathSegment(line[7:])
-		case strings.HasPrefix(line, "OPTIONS /"):
-			method.HTTPMethod = http.MethodOptions
-			method.HTTPPath = normalizePathSegment(line[8:])
 		case strings.HasPrefix(line, "HEAD /"):
 			method.HTTPMethod = http.MethodHead
 			method.HTTPPath = normalizePathSegment(line[5:])

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"go/ast"
+	"go/doc"
 	"go/parser"
 	"go/token"
 	"io/ioutil"
@@ -35,6 +36,7 @@ func ParseFile(inputPath string) (*Context, error) {
 	}
 
 	ctx := &Context{
+		FileSet:      fileSet,
 		File:         file,
 		Path:         inputPath,
 		AbsolutePath: absolutePath,
@@ -52,6 +54,10 @@ func ParseFile(inputPath string) (*Context, error) {
 	if ctx.Services, err = ParseServices(ctx); err != nil {
 		return nil, fmt.Errorf("[%s] parse error: %w", inputPath, err)
 	}
+	if err = ApplyDocumentation(ctx); err != nil {
+		return nil, fmt.Errorf("[%s] parse error: %w", inputPath, err)
+	}
+
 	return ctx, nil
 }
 
@@ -253,61 +259,13 @@ func ParseServiceMethod(ctx *Context, serviceNode *ast.Object, methodObj *ast.Fi
 	method.Request = ctx.ModelByName(typeName(function.Params.List[1]))
 	method.Response = ctx.ModelByName(typeName(function.Results.List[0]))
 
-	// Check the doc comments for the function to determine if they're providing
-	// a custom method/path for the endpoint as opposed to the default RPC-style we assign.
-	applyMethodCommentOptions(ctx, methodObj, method)
 	return method, nil
-}
-
-// applyMethodCommentOptions looks at all of your GoDoc comments for some of the "super special" ones
-// that actually apply different options to your service method. For instance it looks for comments
-// like "HTTP 202" to change the output HTTP status cod the operation.
-func applyMethodCommentOptions(_ *Context, methodObj *ast.Field, method *ServiceMethodDeclaration) {
-	if methodObj.Doc == nil {
-		return
-	}
-	for _, doc := range methodObj.Doc.List {
-		// The raw strings in the AST still look like "// HTTP 202" so normalize it down to
-		// just "HTTP 202" without slashes/spaces, etc.
-		comment := doc.Text
-		comment = strings.TrimSpace(comment)
-		comment = strings.TrimPrefix(comment, "//")
-		comment = strings.TrimSpace(comment)
-
-		switch {
-		case strings.HasPrefix(comment, "GET /"):
-			method.HTTPMethod = http.MethodGet
-			method.HTTPPath = comment[4:]
-		case strings.HasPrefix(comment, "PUT /"):
-			method.HTTPMethod = http.MethodPut
-			method.HTTPPath = comment[4:]
-		case strings.HasPrefix(comment, "POST /"):
-			method.HTTPMethod = http.MethodPost
-			method.HTTPPath = comment[5:]
-		case strings.HasPrefix(comment, "PATCH /"):
-			method.HTTPMethod = http.MethodPatch
-			method.HTTPPath = comment[6:]
-		case strings.HasPrefix(comment, "DELETE /"):
-			method.HTTPMethod = http.MethodDelete
-			method.HTTPPath = comment[7:]
-		case strings.HasPrefix(comment, "OPTIONS /"):
-			method.HTTPMethod = http.MethodOptions
-			method.HTTPPath = comment[8:]
-		case strings.HasPrefix(comment, "HEAD /"):
-			method.HTTPMethod = http.MethodHead
-			method.HTTPPath = comment[5:]
-		case strings.HasPrefix(comment, "HTTP "):
-			method.HTTPStatus = parseHTTPStatus(comment[5:])
-		default:
-			method.Documentation = append(method.Documentation, comment)
-		}
-	}
-	method.Documentation = method.Documentation.Trim()
 }
 
 // parseHTTPStatus is just a strconv.ParseInt that parses the right hand side of an "HTTP 202"
 // looking comment. If we can't parse it as a number for any reason, we'll default to 200.
 func parseHTTPStatus(statusText string) int {
+	statusText = strings.TrimSpace(statusText)
 	status, err := strconv.ParseInt(statusText, 10, 64)
 	if err != nil {
 		return http.StatusOK
@@ -399,6 +357,127 @@ func IsModelDeclaration(astObj *ast.Object) bool {
 	default:
 		return false
 	}
+}
+
+func ApplyDocumentation(ctx *Context) error {
+	docs, err := doc.NewFromFiles(ctx.FileSet, []*ast.File{ctx.File}, ctx.Module.Name)
+	if err != nil {
+		return err
+	}
+
+	// Look through all of the top-level type definitions for structs/aliases you used as
+	// request/response models and process their comments.
+	for _, typeDef := range docs.Types {
+		model := ctx.ModelByName(typeDef.Name)
+		ApplyModelDocumentation(ctx, model, typeDef.Doc)
+	}
+
+	// Look through all of the top-level service interface definitions and apply all of the
+	// documentation options/comments to the service and its methods.
+	for _, typeDef := range docs.Types {
+		service := ctx.ServiceByName(typeDef.Name)
+		if service == nil {
+			continue
+		}
+		ApplyServiceDocumentation(ctx, service, typeDef.Doc)
+
+		// You might ask yourself why we're going back to the original syntax tree to iterate
+		// the service methods rather than iterating 'typeDef.Funcs'. Well... because in all of
+		// my testing this stuff out on real .go files, both ".Methods" and ".Funcs" are nil
+		// on the service interface documentation nodes. Even when the functions have GoDoc
+		// comments, they're nil.
+		//
+		// I'm probably doing something wrong to get in this situation or maybe I just don't fully
+		// understand the syntax tree parsing logic well enough (likely both). But here's what I'm
+		// observing: all of the documentation/comment data on the original AST is missing for
+		// the top-level type definitions (services and models), so I need to actually invoke the
+		// GoDoc parser (doc.NewFromFiles() above) to get those comments. For the interface functions,
+		// however, I'm seeing the exact opposite. The original AST *does* have the comments on those
+		// interface functions, but I can't seem to get to them when using the 'docs' tree.
+		//
+		// That's why I'm mixing and matching where I'm getting the docs from. Models/services come
+		// from the GoDoc parser and the function docs come from the original AST nodes. Maybe one day
+		// I'll learn what the heck is going on and deal with it properly, but for now this does
+		// effectively give me what I want - the complete doc comments for all items in my context.
+		for _, methodObj := range service.InterfaceNode().Methods.List {
+			if methodObj.Doc == nil {
+				continue
+			}
+			method := service.MethodByName(fieldName(methodObj))
+			ApplyMethodDocumentation(ctx, method, methodObj.Doc.Text())
+		}
+	}
+	return nil
+}
+
+func ApplyServiceDocumentation(_ *Context, service *ServiceDeclaration, comments string) {
+	if service == nil {
+		return
+	}
+	if comments == "" {
+		return
+	}
+	for _, line := range strings.Split(comments, "\n") {
+		switch {
+		case strings.HasPrefix(line, "PATH "):
+			service.HTTPPathPrefix = normalizePathSegment(line[5:])
+		case strings.HasPrefix(line, "PREFIX "):
+			service.HTTPPathPrefix = normalizePathSegment(line[7:])
+		default:
+			service.Documentation = append(service.Documentation, line)
+		}
+	}
+	service.Documentation = service.Documentation.Trim()
+}
+
+func ApplyMethodDocumentation(_ *Context, method *ServiceMethodDeclaration, comments string) {
+	if method == nil {
+		return
+	}
+	if comments == "" {
+		return
+	}
+	for _, line := range strings.Split(comments, "\n") {
+		switch {
+		case strings.HasPrefix(line, "GET /"):
+			method.HTTPMethod = http.MethodGet
+			method.HTTPPath = normalizePathSegment(line[4:])
+		case strings.HasPrefix(line, "PUT /"):
+			method.HTTPMethod = http.MethodPut
+			method.HTTPPath = normalizePathSegment(line[4:])
+		case strings.HasPrefix(line, "POST /"):
+			method.HTTPMethod = http.MethodPost
+			method.HTTPPath = normalizePathSegment(line[5:])
+		case strings.HasPrefix(line, "PATCH /"):
+			method.HTTPMethod = http.MethodPatch
+			method.HTTPPath = normalizePathSegment(line[6:])
+		case strings.HasPrefix(line, "DELETE /"):
+			method.HTTPMethod = http.MethodDelete
+			method.HTTPPath = normalizePathSegment(line[7:])
+		case strings.HasPrefix(line, "OPTIONS /"):
+			method.HTTPMethod = http.MethodOptions
+			method.HTTPPath = normalizePathSegment(line[8:])
+		case strings.HasPrefix(line, "HEAD /"):
+			method.HTTPMethod = http.MethodHead
+			method.HTTPPath = normalizePathSegment(line[5:])
+		case strings.HasPrefix(line, "HTTP "):
+			method.HTTPStatus = parseHTTPStatus(line[5:])
+		default:
+			method.Documentation = append(method.Documentation, line)
+		}
+	}
+	method.Documentation = method.Documentation.Trim()
+}
+
+func ApplyModelDocumentation(_ *Context, model *ServiceModelDeclaration, comments string) {
+	if model == nil {
+		return
+	}
+	if comments == "" {
+		return
+	}
+	model.Documentation = strings.Split(comments, "\n")
+	model.Documentation = model.Documentation.Trim()
 }
 
 func fieldName(field *ast.Field) string {

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -152,7 +152,7 @@ func (c Client) buildURL(method string, path string, serviceRequest interface{})
 	}
 
 	// If we're doing a POST/PUT/PATCH, don't bother adding query string arguments.
-	address := c.BaseURL + c.PathPrefix + "/" + strings.Join(pathSegments, "/")
+	address := c.BaseURL + toEndpointPath(c.PathPrefix, strings.Join(pathSegments, "/"))
 	if shouldEncodeUsingBody(method) {
 		return address
 	}
@@ -183,21 +183,4 @@ func writeMetadataHeader(request *http.Request, next RoundTripperFunc) (*http.Re
 	}
 	request.Header.Set(metadata.RequestHeader, encodedValues)
 	return next(request)
-}
-
-// WithClientPrefix should match what you supply if you call WithPrefix when building your service
-// gateway so that all endpoint URLs will be constructed consistently.
-func WithClientPrefix(pathPrefix string) ClientOption {
-	return func(client *Client) {
-		switch {
-		case pathPrefix == "":
-			return
-		case pathPrefix == "/":
-			return
-		case strings.HasPrefix(pathPrefix, "/"):
-			client.PathPrefix = pathPrefix
-		default:
-			client.PathPrefix = "/" + pathPrefix
-		}
-	}
 }

--- a/rpc/gateway.go
+++ b/rpc/gateway.go
@@ -75,8 +75,17 @@ func (gw *Gateway) Register(endpoint Endpoint) {
 	// the user), but the user will never have to see the "/v2" portion.
 	path := toEndpointPath(gw.PathPrefix, endpoint.Path)
 
+	// If you're registering "POST /FooService.Bar" we're going to create a route for
+	// the POST as well as an additional, implicit OPTIONS route. This is so that
+	// you can use WithMiddleware(Func) to enable CORS in your API. All of your middleware
+	// is actually part of the router/mux handling (see comments in New() for details as to why), so
+	// if we don't include an explicit OPTIONS route for this path then your CORS middleware
+	// will never actually get invoked - httprouter will just reject the request. We fully expect
+	// your CORS middleware to short-circuit the 'next' chain, so the 405 failure we're hard-coding
+	// as the OPTIONS handler won't actually be invoked if you enable CORS via middleware.
 	gw.endpoints[path] = endpoint
 	gw.Router.HandlerFunc(endpoint.Method, path, gw.middleware.Then(endpoint.Handler))
+	gw.Router.HandlerFunc(http.MethodOptions, path, gw.middleware.Then(methodNotAllowedHandler{}.ServeHTTP))
 }
 
 // ServeHTTP is the central HTTP handler that includes all http routing, middleware, service forwarding, etc.
@@ -164,4 +173,13 @@ func toEndpointPath(prefix string, path string) string {
 	default:
 		return "/" + prefix + "/" + path
 	}
+}
+
+// methodNotAllowedHandler just replies with a 405 error status no matter what. It's the
+// default OPTIONS handler we use so that you can insert the CORS middleware of your
+// choice should you choose to enable browser-based communication w/ your service.
+type methodNotAllowedHandler struct{}
+
+func (methodNotAllowedHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	respond.To(w, req).MethodNotAllowed("")
 }


### PR DESCRIPTION
* Services and models now capture GoDoc comments just like service functions did.
* API path prefix is now a doc option on the service interface rather than client/gateway functional options.
* Unrelated by lazy additional commit - CORS preflight middleware now works when using WithMiddleware
* Fixed README bug w/ middleware example