### PR TITLE
Type parsing and OpenAPI docs

### DIFF
--- a/cli/generate_client.go
+++ b/cli/generate_client.go
@@ -45,6 +45,8 @@ func (c GenerateClient) Exec(request *GenerateClientRequest) error {
 		return c.generate(request, generate.TemplateClientGo)
 	case "js", "javascript", "node", "nodejs":
 		return c.generate(request, generate.TemplateClientJS)
+	case "swagger", "openapi":
+		return c.generate(request, generate.TemplateClientSwagger)
 	default:
 		return fmt.Errorf("unsupported client language")
 	}

--- a/example/posts/gen/post_service.gen.client.go
+++ b/example/posts/gen/post_service.gen.client.go
@@ -1,5 +1,5 @@
 // !!!!!!! DO NOT EDIT !!!!!!!
-// Auto-generated client code from post_service.go
+// Auto-generated client code from example/posts/post_service.go
 // !!!!!!! DO NOT EDIT !!!!!!!
 package postsrpc
 
@@ -40,7 +40,7 @@ func (client *PostServiceClient) GetPost(ctx context.Context, request *posts.Get
 	}
 
 	response := &posts.GetPostResponse{}
-	err := client.Invoke(ctx, "POST", "/PostService.GetPost", request, response)
+	err := client.Invoke(ctx, "GET", "post/:id", request, response)
 	return response, err
 }
 
@@ -54,7 +54,7 @@ func (client *PostServiceClient) CreatePost(ctx context.Context, request *posts.
 	}
 
 	response := &posts.CreatePostResponse{}
-	err := client.Invoke(ctx, "POST", "/PostService.CreatePost", request, response)
+	err := client.Invoke(ctx, "POST", "post", request, response)
 	return response, err
 }
 
@@ -68,7 +68,7 @@ func (client *PostServiceClient) Archive(ctx context.Context, request *posts.Arc
 	}
 
 	response := &posts.ArchiveResponse{}
-	err := client.Invoke(ctx, "POST", "/PostService.Archive", request, response)
+	err := client.Invoke(ctx, "PATCH", "post/:id/archive", request, response)
 	return response, err
 }
 

--- a/example/posts/post_service.go
+++ b/example/posts/post_service.go
@@ -2,7 +2,7 @@ package posts
 
 import (
 	"context"
-	"time"
+	chrono "time"
 )
 
 // PostService is a service that manages blog/article posts. This is just for example purposes,
@@ -12,19 +12,29 @@ import (
 // PATH /v2
 type PostService interface {
 	// GetPost fetches a Post record by its unique identifier.
+	//
+	// GET /post/:id
 	GetPost(context.Context, *GetPostRequest) (*GetPostResponse, error)
 	// CreatePost creates/stores a new Post record.
+	//
+	// POST /post
 	CreatePost(context.Context, *CreatePostRequest) (*CreatePostResponse, error)
 	// Archive effectively disables a Post from appearing in the article list.
+	// PATCH /post/:id/archive
+	// HTTP 202
 	Archive(context.Context, *ArchiveRequest) (*ArchiveResponse, error)
 }
 
+type ShortText string
+
 type Post struct {
-	ID       string
-	Title    string
-	Text     string
-	Archived bool
-	Date     time.Time
+	ID string
+	// Title is the one-line headline for the post.
+	Title ShortText
+	Text  string
+	// Archived determines if the post is active or not.
+	Archived *bool
+	Date     chrono.Time
 }
 
 type GetPostRequest struct {

--- a/example/posts/post_service.go
+++ b/example/posts/post_service.go
@@ -28,6 +28,7 @@ type PostService interface {
 type ShortText string
 
 type Post struct {
+	// ID is the unique record identifier of the post.
 	ID string
 	// Title is the one-line headline for the post.
 	Title ShortText
@@ -38,6 +39,7 @@ type Post struct {
 }
 
 type GetPostRequest struct {
+	// ID is the unique identifier of the post to fetch.
 	ID string
 }
 

--- a/generate/client.go
+++ b/generate/client.go
@@ -39,7 +39,7 @@ type {{ .Name }}Client struct {
 {{ range .Methods }}
 {{ range .Documentation }}
 // {{ . }}{{ end }}
-func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, request *{{ $ctx.Package.Name }}.{{ .Request.Name }}) (*{{ $ctx.Package.Name }}.{{ .Response.Name }}, error) {
+func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, request *{{ $ctx.Package.Name }}.{{ .Request.Name | NonPointer }}) (*{{ $ctx.Package.Name }}.{{ .Response.Name | NonPointer }}, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("precondition failed: nil context")
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -81,4 +81,41 @@ var templateFuncs = template.FuncMap{
 	"HTTPMethodSupportsBody": func(method string) bool {
 		return method == "POST" || method == "PUT" || method == "PATCH"
 	},
+	"LeadingSlash": func(value string) string {
+		if strings.HasPrefix(value, "/") {
+			return value
+		}
+		return "/" + value
+	},
+	"NonPointer": func(value string) string {
+		if strings.HasPrefix(value, "*") {
+			return value[1:]
+		}
+		if strings.HasPrefix(value, "&") {
+			return value[1:]
+		}
+		return value
+	},
+	"ToLower": func(value string) string {
+		return strings.ToLower(value)
+	},
+	"EmptyString": func(value string) bool {
+		return value == ""
+	},
+	"NotEmptyString": func(value string) bool {
+		return value != ""
+	},
+	"OpenAPIPath": func(path string) string {
+		segments := strings.Split(path, "/")
+		for i, segment := range segments {
+			if strings.HasPrefix(segment, ":") {
+				segments[i] = "{" + segment[1:] + "}"
+			}
+		}
+		path = strings.Join(segments, "/")
+		if strings.HasPrefix(path, "/") {
+			return path
+		}
+		return "/" + path
+	},
 }

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -172,7 +172,8 @@ function trimSlashes(value) {
 {{ range .Models }}
 /** {{ range .Documentation }}
  * {{ . }}{{ end }}
- * @typedef {Object|*} {{ .Name }}
+ * @typedef {Object|*} {{ .Name }}{{ range .Fields }}
+ * @property {*|{{ .Type.JSONType }} } {{ .Name }}{{ end }}
  */
 {{ end }}
 

--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -12,11 +12,24 @@ servers:
 
 paths:
 {{ range $method := .Methods }}
-    "{{ .HTTPPath | OpenAPIPath}}":
+{{ $pathFields := .HTTPPathParameters }}
+    "{{ .HTTPPath | OpenAPIPath }}":
         {{ .HTTPMethod | ToLower }}:
             description: > {{ range .Documentation }}
-                {{ . }}
-{{ end }}
+                {{ . }}{{ end }}
+            {{ if $pathFields.NotEmpty }}
+            parameters:
+                {{ range $pathFields }}
+                - in: path
+                  name: {{ .Name }}
+                  required: true
+                  {{ if .Field.Documentation.NotEmpty }}
+                  description: {{ .Field.Documentation.Summary }}
+                  {{ end }}
+                  schema:
+                      type: {{ .Field.Type.JSONType }}
+                {{ end }}
+            {{ end }}
             {{ if .HTTPMethod | HTTPMethodSupportsBody }}
             requestBody:
                 content:

--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -1,0 +1,54 @@
+package generate
+
+// TemplateClientSwagger is the text template that generates the Swagger JSON for your API
+var TemplateClientSwagger = parseArtifactTemplate("swagger.yaml", `{{ range $service := .Services }}
+openapi: 3.0.0
+info:
+    title: {{ .Name }}
+    version: "{{ .Version }}"
+
+servers:
+    - url: {{ .HTTPPathPrefix | LeadingSlash }}
+
+paths:
+{{ range $method := .Methods }}
+    "{{ .HTTPPath | OpenAPIPath}}":
+        {{ .HTTPMethod | ToLower }}:
+            description: > {{ range .Documentation }}
+                {{ . }}
+{{ end }}
+            {{ if .HTTPMethod | HTTPMethodSupportsBody }}
+            requestBody:
+                content:
+                     application/json:
+                         schema:
+                             $ref: '#/components/schemas/{{ .Request.Name }}'
+            {{ end }}
+                
+            responses:
+                {{ .HTTPStatus }}:
+                    description: Success
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/{{ .Response.Name }}'
+{{ end }}
+
+{{ end }}
+
+components:
+    schemas:
+{{ range $model := .Models }}
+        {{ .Name }}:
+            type: object
+            {{ if .Fields.NotEmpty }}properties:
+{{ range $field := .Fields }}
+                {{ .Name }}:
+                    type: {{ .Type.JSONType }}
+                    {{ if .Documentation.NotEmpty }}description: > {{ range .Documentation }} 
+                        {{ . }}{{ end }}
+                    {{ end }}
+            {{ end }}
+{{ end }}
+{{ end }}
+`)

--- a/parser/context.go
+++ b/parser/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"go/types"
 	"path/filepath"
 	"strings"
 )
@@ -31,6 +32,8 @@ type Context struct {
 	Services []*ServiceDeclaration
 	// Models encapsulates snapshot info for all service request/response structs that were defined in the input file.
 	Models []*ServiceModelDeclaration
+	// TypeInfo contains detailed compiler info about the types in your source file.
+	TypeInfo *types.Info
 }
 
 // ServiceByName looks through "Services" to find the one with the matching interface name.
@@ -45,6 +48,13 @@ func (ctx Context) ServiceByName(name string) *ServiceDeclaration {
 
 // ModelByName looks through "Models" to find the one whose method/function name matches 'name'.
 func (ctx Context) ModelByName(name string) *ServiceModelDeclaration {
+	// These lookups likely happen when we perform lookups for service method parameters. Those are
+	// usually pointers (e.g. "*GetPostRequest). The model name we put on the context does not have
+	// any sort of pointer identification, so strip that off.
+	if strings.HasPrefix(name, "*") {
+		name = name[1:]
+	}
+
 	for _, model := range ctx.Models {
 		if model.Name == name {
 			return model
@@ -58,6 +68,9 @@ func (ctx Context) ModelByName(name string) *ServiceModelDeclaration {
 type ServiceDeclaration struct {
 	// Name is the name of the service/interface.
 	Name string
+	// Version is the (hopefully) semantic version of your API (e.g. 1.2.0). This is NOT the prefix
+	// to all routes in the API for the service. It's just an identifier available to code gen tools.
+	Version string
 	// HTTPPathPrefix is the optional version/domain prefix for all endpoints in the API (e.g. "v2/").
 	HTTPPathPrefix string
 	// Methods are all of the functions explicitly defined on this service.
@@ -120,6 +133,8 @@ type ServiceModelDeclaration struct {
 	Name string
 	// Documentation are all of the comments documenting this operation.
 	Documentation DocumentationLines
+	// Fields are the individual data attributes on this model/struct.
+	Fields Fields
 	// Node is the syntax tree object that defined this type/struct.
 	Node *ast.Object
 }
@@ -127,6 +142,44 @@ type ServiceModelDeclaration struct {
 // String just returns the model type's name.
 func (model ServiceModelDeclaration) String() string {
 	return model.Name
+}
+
+type Fields []*FieldDeclaration
+
+func (f Fields) Empty() bool {
+	return len(f) == 0
+}
+
+func (f Fields) NotEmpty() bool {
+	return len(f) > 0
+}
+
+// FieldDeclaration describes a single field in a request/response model.
+type FieldDeclaration struct {
+	// Name the name of the field/attribute.
+	Name string
+	// Type contains the data type information for this field.
+	Type *FieldType
+	// Documentation are all of the comments documenting this field.
+	Documentation DocumentationLines
+	// Node is the syntax tree object where this field was defined.
+	Node *ast.Field
+}
+
+type FieldType struct {
+	// Name is the fully qualified name/expression for the type (e.g. "uint", "time.Time", "*Foo", "[]byte", etc).
+	Name       string
+	Pointer    bool
+	Type       types.Type
+	Underlying types.Type
+	// Elem is only non-nil for slice/array/chan types. If the slice is this field type, the ElemType
+	// describes what the type of each element describes.
+	Elem *FieldType
+	// Key is only non-nil for tuple/map types where there's some key/value pairing. It describes the type
+	// of all of the keys in the collection whereas ElemType describes the value.
+	Key *FieldType
+	// JSONType is the name of the JS/JSON type that this most naturally maps to (number/string/boolean/object/array).
+	JSONType string
 }
 
 // ModuleDeclaration contains information about the Go module that the service belongs
@@ -159,7 +212,7 @@ type DocumentationLines []string
 
 // Trim removes blank doc lines from the front/back of your list of comments.
 func (docs DocumentationLines) Trim() DocumentationLines {
-	if len(docs) == 0 {
+	if docs.Empty() {
 		return docs
 	}
 	// We want to be able to trim leading and trailing blank lines in a single pass over the
@@ -182,6 +235,14 @@ func (docs DocumentationLines) Trim() DocumentationLines {
 		}
 	}
 	return docs[first : last+1]
+}
+
+func (docs DocumentationLines) NotEmpty() bool {
+	return len(docs) > 0
+}
+
+func (docs DocumentationLines) Empty() bool {
+	return len(docs) == 0
 }
 
 func normalizePathSegment(path string) string {

--- a/parser/parse.go
+++ b/parser/parse.go
@@ -650,15 +650,15 @@ func ApplyModelDocumentation(_ *Context, model *ServiceModelDeclaration, comment
 }
 
 // ApplyFieldDocumentation
-func ApplyFieldDocumentation(_ *Context, fields *FieldDeclaration, comments string) {
-	if fields == nil {
+func ApplyFieldDocumentation(_ *Context, field *FieldDeclaration, comments string) {
+	if field == nil {
 		return
 	}
 	if comments == "" {
 		return
 	}
-	fields.Documentation = strings.Split(comments, "\n")
-	fields.Documentation = fields.Documentation.Trim()
+	field.Documentation = strings.Split(comments, "\n")
+	field.Documentation = field.Documentation.Trim()
 }
 
 func fieldName(field *ast.Field) string {


### PR DESCRIPTION
This is a "stable enough" merge of code that uses the `go/types` package to parse type information about type defs and fields so that we can get detailed information about the types you're defining in your service. That has been mashed into a "client" output for OpenAPI (swagger) documentation.