### PR TITLE
Refactor: method->function, extract gateway options

### DIFF
--- a/example/posts/gen/post_service.gen.gateway.go
+++ b/example/posts/gen/post_service.gen.gateway.go
@@ -1,5 +1,5 @@
 // !!!!!!! DO NOT EDIT !!!!!!!
-// Auto-generated server code from post_service.go
+// Auto-generated server code from example/posts/post_service.go
 // !!!!!!! DO NOT EDIT !!!!!!!
 package postsrpc
 
@@ -28,8 +28,8 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 	gw.PathPrefix = "v2"
 
 	gw.Register(rpc.Endpoint{
-		Method:      "POST",
-		Path:        "/PostService.GetPost",
+		Method:      "GET",
+		Path:        "post/:id",
 		ServiceName: "PostService",
 		Name:        "GetPost",
 		Handler: func(w http.ResponseWriter, req *http.Request) {
@@ -48,7 +48,7 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 
 	gw.Register(rpc.Endpoint{
 		Method:      "POST",
-		Path:        "/PostService.CreatePost",
+		Path:        "post",
 		ServiceName: "PostService",
 		Name:        "CreatePost",
 		Handler: func(w http.ResponseWriter, req *http.Request) {
@@ -66,8 +66,8 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 	})
 
 	gw.Register(rpc.Endpoint{
-		Method:      "POST",
-		Path:        "/PostService.Archive",
+		Method:      "PATCH",
+		Path:        "post/:id/archive",
 		ServiceName: "PostService",
 		Name:        "Archive",
 		Handler: func(w http.ResponseWriter, req *http.Request) {
@@ -80,7 +80,7 @@ func NewPostServiceGateway(service posts.PostService, options ...rpc.GatewayOpti
 			}
 
 			serviceResponse, err := service.Archive(req.Context(), &serviceRequest)
-			response.Reply(200, serviceResponse, err)
+			response.Reply(202, serviceResponse, err)
 		},
 	})
 

--- a/example/posts/post_service.go
+++ b/example/posts/post_service.go
@@ -40,7 +40,10 @@ type Post struct {
 
 type GetPostRequest struct {
 	// ID is the unique identifier of the post to fetch.
-	ID string
+	ID    string
+	Limit int
+	// Offset is like the SQL offset, dummy.
+	Offset int
 }
 
 // GetPostResponse describes a single post in the blog.

--- a/example/posts/post_service.go
+++ b/example/posts/post_service.go
@@ -1,7 +1,7 @@
 package posts
 
 import (
-	"context"
+	real "context"
 	chrono "time"
 )
 
@@ -14,15 +14,15 @@ type PostService interface {
 	// GetPost fetches a Post record by its unique identifier.
 	//
 	// GET /post/:id
-	GetPost(context.Context, *GetPostRequest) (*GetPostResponse, error)
+	GetPost(real.Context, *GetPostRequest) (*GetPostResponse, error)
 	// CreatePost creates/stores a new Post record.
 	//
 	// POST /post
-	CreatePost(context.Context, *CreatePostRequest) (*CreatePostResponse, error)
+	CreatePost(real.Context, *CreatePostRequest) (*CreatePostResponse, error)
 	// Archive effectively disables a Post from appearing in the article list.
 	// PATCH /post/:id/archive
 	// HTTP 202
-	Archive(context.Context, *ArchiveRequest) (*ArchiveResponse, error)
+	Archive(real.Context, *ArchiveRequest) (*ArchiveResponse, error)
 }
 
 type ShortText string
@@ -51,7 +51,9 @@ type CreatePostRequest struct {
 	Text  string
 }
 
-type CreatePostResponse Post
+type CreatePostResponse struct {
+	Post
+}
 
 type ArchiveRequest struct {
 	ID string
@@ -59,3 +61,5 @@ type ArchiveRequest struct {
 
 type ArchiveResponse struct {
 }
+
+type ISODate chrono.Time

--- a/generate/client.go
+++ b/generate/client.go
@@ -24,7 +24,7 @@ import (
 // {{ . }}{{end}}
 func New{{ .Name }}Client(address string, options ...rpc.ClientOption) *{{ .Name }}Client {
 	rpcClient := rpc.NewClient("{{ .Name }}", address, options...)
-	rpcClient.PathPrefix = "{{ .HTTPPathPrefix }}"
+	rpcClient.PathPrefix = "{{ .Gateway.PathPrefix }}"
 	return &{{ .Name }}Client{Client: rpcClient} 
 }
 
@@ -48,7 +48,7 @@ func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, reque
 	}
 
 	response := &{{ $ctx.Package.Name }}.{{ .Response.Name }}{}
-	err := client.Invoke(ctx, "{{ .HTTPMethod }}", "{{ .HTTPPath }}", request, response)
+	err := client.Invoke(ctx, "{{ .Gateway.Method }}", "{{ .Gateway.Path }}", request, response)
 	return response, err
 }
 {{ end }}

--- a/generate/client.go
+++ b/generate/client.go
@@ -36,7 +36,7 @@ type {{ .Name }}Client struct {
 }
 
 {{ $service := . }}
-{{ range .Methods }}
+{{ range .Functions }}
 {{ range .Documentation }}
 // {{ . }}{{ end }}
 func (client *{{ $service.Name }}Client) {{ .Name }} (ctx context.Context, request *{{ $ctx.Package.Name }}.{{ .Request.Name | NonPointer }}) (*{{ $ctx.Package.Name }}.{{ .Response.Name | NonPointer }}, error) {
@@ -64,7 +64,7 @@ type {{ .Name }}Proxy struct {
 	Service {{ $ctx.Package.Name }}.{{ .Name }}
 }
 
-{{ range .Methods }}
+{{ range .Functions }}
 func (proxy *{{ $service.Name }}Proxy) {{ .Name }} (ctx context.Context, request *{{ $ctx.Package.Name }}.{{ .Request.Name }}) (*{{ $ctx.Package.Name }}.{{ .Response.Name }}, error) {
 	return proxy.Service.{{ .Name }}(ctx, request)
 }

--- a/generate/gateway.go
+++ b/generate/gateway.go
@@ -33,7 +33,7 @@ func New{{ .Name }}Gateway(service {{ $ctx.Package.Name }}.{{ .Name }}, options 
 	gw.PathPrefix = "{{ .HTTPPathPrefix }}"
 
 	{{ $service := . }}
-	{{ range $service.Methods }}
+	{{ range $service.Functions }}
 	gw.Register(rpc.Endpoint{
 		Method:      "{{ .HTTPMethod }}",
 		Path:        "{{ .HTTPPath }}",

--- a/generate/gateway.go
+++ b/generate/gateway.go
@@ -30,13 +30,13 @@ import (
 func New{{ .Name }}Gateway(service {{ $ctx.Package.Name }}.{{ .Name }}, options ...rpc.GatewayOption) rpc.Gateway {
 	gw := rpc.NewGateway(options...)
 	gw.Name = "{{ .Name }}"
-	gw.PathPrefix = "{{ .HTTPPathPrefix }}"
+	gw.PathPrefix = "{{ .Gateway.PathPrefix }}"
 
 	{{ $service := . }}
 	{{ range $service.Functions }}
 	gw.Register(rpc.Endpoint{
-		Method:      "{{ .HTTPMethod }}",
-		Path:        "{{ .HTTPPath }}",
+		Method:      "{{ .Gateway.Method }}",
+		Path:        "{{ .Gateway.Path }}",
 		ServiceName: "{{ $service.Name }}",
 		Name:        "{{ .Name }}",
 		Handler:     func(w http.ResponseWriter, req *http.Request) {
@@ -49,7 +49,7 @@ func New{{ .Name }}Gateway(service {{ $ctx.Package.Name }}.{{ .Name }}, options 
 			}
 
 			serviceResponse, err := service.{{ .Name }}(req.Context(), &serviceRequest)
-			response.Reply({{ .HTTPStatus }}, serviceResponse, err)
+			response.Reply({{ .Gateway.Status }}, serviceResponse, err)
 		},
 	})
 	{{ end }}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -78,9 +78,6 @@ func parseArtifactTemplate(name string, text string) *template.Template {
 // templateFuncs are all of pipe functions we want available when evaluating the Go template
 // to generate an artifact's source code.
 var templateFuncs = template.FuncMap{
-	"HTTPMethodSupportsBody": func(method string) bool {
-		return method == "POST" || method == "PUT" || method == "PATCH"
-	},
 	"LeadingSlash": func(value string) string {
 		if strings.HasPrefix(value, "/") {
 			return value

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -23,7 +23,7 @@ class {{ .Name }}Client {
         this._fetch = fetch || defaultFetch;
     }
 
-    {{ range .Methods }}
+    {{ range .Functions }}
     /**{{ range $doc := .Documentation }}
      * {{ . }} {{ end }}
      *

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -172,8 +172,8 @@ function trimSlashes(value) {
 {{ range .Models }}
 /** {{ range .Documentation }}
  * {{ . }}{{ end }}
- * @typedef {Object|*} {{ .Name }}{{ range .Fields }}
- * @property {*|{{ .Type.JSONType }} } {{ .Name }}{{ end }}
+ * @typedef { {{ .Type.JSONType }} } {{ .Name }}{{ range .Fields }}
+ * @property { {{ .Type.JSONType }} } {{ .Name }}{{ end }}
  */
 {{ end }}
 

--- a/generate/javascript.go
+++ b/generate/javascript.go
@@ -19,7 +19,7 @@ class {{ .Name }}Client {
     _fetch;
 
     constructor(baseURL, {fetch} = {}) {
-        this._baseURL = trimSlashes(trimSlashes(baseURL) + '/' + trimSlashes('{{ .HTTPPathPrefix}}'));
+        this._baseURL = trimSlashes(trimSlashes(baseURL) + '/' + trimSlashes('{{ .Gateway.PathPrefix}}'));
         this._fetch = fetch || defaultFetch;
     }
 
@@ -31,16 +31,16 @@ class {{ .Name }}Client {
      * @returns {Promise<{{ .Response.Name }}>} The JSON-encoded return value of the operation.
      */
     async {{ .Name }}(serviceRequest) {
-        const url = this._baseURL + buildRequestPath('{{ .HTTPMethod }}', '{{ .HTTPPath }}', serviceRequest);
-        {{ if .HTTPMethod | HTTPMethodSupportsBody }}const bodyJSON = JSON.stringify(serviceRequest);{{ end }}
+        const url = this._baseURL + buildRequestPath('{{ .Gateway.Method }}', '{{ .Gateway.Path }}', serviceRequest);
+        {{ if .Gateway.SupportsBody }}const bodyJSON = JSON.stringify(serviceRequest);{{ end }}
 
         const options = {
-            method: '{{ .HTTPMethod }}',
+            method: '{{ .Gateway.Method }}',
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json; charset=utf-8',
             },
-            {{ if .HTTPMethod | HTTPMethodSupportsBody }}body: bodyJSON,{{ end }}
+            {{ if .Gateway.SupportsBody }}body: bodyJSON,{{ end }}
         };
         const response = await this._fetch(url, options);
         return handleResponse(response);

--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -24,7 +24,8 @@ paths:
                   name: {{ .Name }}
                   required: true
                   {{ if .Field.Documentation.NotEmpty }}
-                  description: {{ .Field.Documentation.Summary }}
+                  description:  > {{ range .Field.Documentation }} 
+                      {{ . }}{{ end }}
                   {{ end }}
                   schema:
                       type: {{ .Field.Type.JSONType }}

--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -8,16 +8,17 @@ info:
     version: "{{ .Version }}"
 
 servers:
-    - url: {{ .HTTPPathPrefix | LeadingSlash }}
+    - url: {{ .Gateway.PathPrefix | LeadingSlash }}
 
 paths:
 {{ range $method := .Functions }}
-{{ $pathFields := .HTTPPathParameters }}
-    "{{ .HTTPPath | OpenAPIPath }}":
-        {{ .HTTPMethod | ToLower }}:
+{{ $pathFields := .Gateway.PathParameters }}
+{{ $queryFields := .Gateway.QueryParameters }}
+    "{{ .Gateway.Path | OpenAPIPath }}":
+        {{ .Gateway.Method | ToLower }}:
             description: > {{ range .Documentation }}
                 {{ . }}{{ end }}
-            {{ if $pathFields.NotEmpty }}
+            {{ if or $pathFields.NotEmpty $queryFields.NotEmpty }}
             parameters:
                 {{ range $pathFields }}
                 - in: path
@@ -30,8 +31,18 @@ paths:
                   schema:
                       type: {{ .Field.Type.JSONType }}
                 {{ end }}
+                {{ range $queryFields }}
+                - in: query
+                  name: {{ .Name }}
+                  {{ if .Field.Documentation.NotEmpty }}
+                  description:  > {{ range .Field.Documentation }} 
+                      {{ . }}{{ end }}
+                  {{ end }}
+                  schema:
+                      type: {{ .Field.Type.JSONType }}
+                {{ end }}
             {{ end }}
-            {{ if .HTTPMethod | HTTPMethodSupportsBody }}
+            {{ if .Gateway.SupportsBody }}
             requestBody:
                 content:
                      application/json:
@@ -40,7 +51,7 @@ paths:
             {{ end }}
                 
             responses:
-                {{ .HTTPStatus }}:
+                {{ .Gateway.Status }}:
                     description: Success
                     content:
                         application/json:

--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -11,7 +11,7 @@ servers:
     - url: {{ .HTTPPathPrefix | LeadingSlash }}
 
 paths:
-{{ range $method := .Methods }}
+{{ range $method := .Functions }}
 {{ $pathFields := .HTTPPathParameters }}
     "{{ .HTTPPath | OpenAPIPath }}":
         {{ .HTTPMethod | ToLower }}:


### PR DESCRIPTION
I refactored some clunky bits for clarity. These are breaking changes, but nobody's using this yet, so.... who cares.

* `ServiceMethod` is now `ServiceFunction`
* Instead of prefixing all HTTP-related options like `function.HTTPMethod` or `function.HTTPPath`, they've been pulled into a separate `Gateway` options struct: `function.Gateway.Method` and `function.Gateway.Path`, etc.

I also utilized the cleaned up code to add query parameters to swagger docs.