### PR TITLE
Field declarations include json tag remapping info.

### DIFF
--- a/generate/swagger.go
+++ b/generate/swagger.go
@@ -11,9 +11,9 @@ servers:
     - url: {{ .Gateway.PathPrefix | LeadingSlash }}
 
 paths:
-{{ range $method := .Functions }}
-{{ $pathFields := .Gateway.PathParameters }}
-{{ $queryFields := .Gateway.QueryParameters }}
+    {{ range $method := .Functions }}
+    {{ $pathFields := .Gateway.PathParameters }}
+    {{ $queryFields := .Gateway.QueryParameters }}
     "{{ .Gateway.Path | OpenAPIPath }}":
         {{ .Gateway.Method | ToLower }}:
             description: > {{ range .Documentation }}
@@ -42,6 +42,7 @@ paths:
                       type: {{ .Field.Type.JSONType }}
                 {{ end }}
             {{ end }}
+
             {{ if .Gateway.SupportsBody }}
             requestBody:
                 content:
@@ -57,23 +58,25 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/{{ .Response.Name }}'
-{{ end }}
-
-{{ end }}
+    {{ end }}
+    {{ end }}
 
 components:
     schemas:
-{{ range $model := .Models }}
+        {{ range $model := .Models }}
         {{ .Name }}:
-            type: object
-            {{ if .Fields.NotEmpty }}properties:
-{{ range $field := .Fields }}
-                {{ .Name }}:
+            type: {{ .Type.JSONType }}
+            {{ if .Fields.NotEmpty }}
+            properties:
+                {{ range $field := .Fields }}
+                {{ if not .Binding.Omit }}
+                {{ .Binding.Name }}:
                     type: {{ .Type.JSONType }}
                     {{ if .Documentation.NotEmpty }}description: > {{ range .Documentation }} 
                         {{ . }}{{ end }}
                     {{ end }}
+                {{ end }}
             {{ end }}
-{{ end }}
-{{ end }}
+            {{ end }}
+        {{ end }}
 `)


### PR DESCRIPTION
When generating JSDoc in the JS templates and when generating swagger docs, field names will use `json:"xxx"` remapped values instead of the raw Go attribute (when possible). That way it clearly indicates the JSON structure you need to provide in order to properly make that call.