### PR TITLE
Proper http status error handling. Fixed client path param building.

### DIFF
--- a/example/comments/comment_service_handler.go
+++ b/example/comments/comment_service_handler.go
@@ -66,6 +66,7 @@ func (svc *CommentServiceHandler) FindByPost(ctx context.Context, request *FindB
 	// some sort of `errors.NotFound()` error if it doesn't exist.
 	_, err := svc.PostService.GetPost(ctx, &posts.GetPostRequest{ID: request.PostID})
 	if err != nil {
+		fmt.Printf(">>>>>> FAIL: [%+v]\n", err)
 		return nil, fmt.Errorf("unable to retrieve post: %w", err)
 	}
 

--- a/internal/reflection/reflection.go
+++ b/internal/reflection/reflection.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 )
 
-func StructToMap(item interface{}) map[string]interface{} {
-	res := map[string]interface{}{}
+// ToAttributes accepts a struct (probably your service request) and returns a list
+// of the key/value pairs for the attribute name/values. This is recursive, so nested
+// structs will be included as the 'Value' of the necessary attributes.
+func ToAttributes(item interface{}) StructAttributes {
+	var attrs StructAttributes
 	if item == nil {
-		return res
+		return attrs
 	}
 
 	valueType := reflect.TypeOf(item)
@@ -19,30 +22,79 @@ func StructToMap(item interface{}) map[string]interface{} {
 	reflectValue := reflect.Indirect(reflect.ValueOf(item))
 
 	for i := 0; i < valueType.NumField(); i++ {
-		name := FieldName(valueType.Field(i))
+		name := BindingName(valueType.Field(i))
 		field := reflectValue.Field(i).Interface()
 		if valueType.Field(i).Type.Kind() == reflect.Struct {
-			res[name] = StructToMap(field)
+			attrs = append(attrs, &StructAttribute{Name: name, Value: ToAttributes(field)})
 		} else {
-			res[name] = field
+			attrs = append(attrs, &StructAttribute{Name: name, Value: field})
 		}
 	}
-	return res
+	return attrs
+}
+
+// StructAttributes maintains a list of attribute names/values for some source struct.
+type StructAttributes []*StructAttribute
+
+// Find looks up the struct attribute with the given name. This search is CASE-INSENSITIVE
+// in order to match how the standard library handles JSON attribute.
+func (attrs StructAttributes) Find(name string) *StructAttribute {
+	for _, attr := range attrs {
+		if attr.Matches(name) {
+			return attr
+		}
+	}
+	return nil
+}
+
+// Remove performs a case-insensitive search for the attribute w/ that name and removes it from
+// the list. The new slice without the matching attribute is returned.
+func (attrs StructAttributes) Remove(name string) StructAttributes {
+	for i, attr := range attrs {
+		if attr.Matches(name) {
+			return append(attrs[:i], attrs[i+1:]...)
+		}
+	}
+	return attrs
+}
+
+// StructAttribute represents a single key/value pair for a field on a struct.
+type StructAttribute struct {
+	// Name is the binding name of the struct value. If there was a JSON tag on the
+	// struct field, it should be that value. Otherwise it's just the struct field's name.
+	Name string
+	// Value is the runtime value of this field on the struct you ran through "ToAttributes()"
+	Value interface{}
+}
+
+// Matches determines if there is a case-insensitive match between this name and the field.
+func (attr StructAttribute) Matches(name string) bool {
+	return strings.EqualFold(name, attr.Name)
 }
 
 var noField = reflect.StructField{}
 
+// FindField looks up the struct field attribute for the given field on the given struct.
 func FindField(structType reflect.Type, name string) (reflect.StructField, bool) {
 	for i := 0; i < structType.NumField(); i++ {
 		field := structType.Field(i)
-		if strings.EqualFold(name, FieldName(field)) {
+		if strings.EqualFold(name, BindingName(field)) {
 			return field, true
 		}
 	}
 	return noField, false
 }
 
-func FieldName(field reflect.StructField) string {
+// BindingName just returns the name of the field/attribute on the struct unless it has a `json` tag
+// defined. If so, it will use the remapped name for this field instead.
+//
+//     type Foo struct {
+//         A string
+//         B string `json:"hello"
+//     }
+//
+// The binding name for the first attribute is "A", but the binding name for the other is "hello".
+func BindingName(field reflect.StructField) string {
 	jsonTag := field.Tag.Get("json")
 	if jsonTag == "" || jsonTag == "-" {
 		return field.Name
@@ -62,6 +114,7 @@ func FieldName(field reflect.StructField) string {
 	}
 }
 
+// Assign simply performs a reflective replace of the value, making sure to try to properly handle pointers.
 func Assign(value interface{}, out interface{}) {
 	// Depending on whether you wrote "SomeStruct{}" or "&SomeStruct{}" (a pointer) to the
 	// scope, we want to make sure that we're de-referencing the scope value properly.


### PR DESCRIPTION
Snuck two things into this one:

* If you used a client to call another service and it threw a non-500 error (e.g. a 404), the error that the client returned lost the original status so everything would propagate forward as a 500 rather than the original. That's fixed.
* Path params in Go client were not properly being filled in if the field name's case didn't match the path param's case. The intent was to be case insensitive since that's how `encoding/json` rolls. Works now.