### PR TITLE
Gateway recovers from panics by default.

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -93,7 +92,6 @@ type Client struct {
 func (c Client) Invoke(ctx context.Context, method string, path string, serviceRequest interface{}, serviceResponse interface{}) error {
 	// Step 1: Fill in the URL path and query string w/ fields from the request. (e.g. /user/:id -> /user/abc)
 	address := c.buildURL(method, path, serviceRequest)
-	log.Printf("Invoking %s -> %s %s", c.Name, method, address)
 
 	// Step 2: Create a JSON reader for the request body (POST/PUT/PATCH only).
 	body, err := c.createRequestBody(method, serviceRequest)

--- a/rpc/gateway.go
+++ b/rpc/gateway.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -165,7 +164,7 @@ func restoreMetadata(w http.ResponseWriter, req *http.Request, next http.Handler
 
 	values, err := metadata.FromJSON(encodedValues)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("rpc metadata error: %v", err.Error()), 400)
+		respond.To(w, req).BadRequest("rpc metadata error: %v", err.Error())
 		return
 	}
 


### PR DESCRIPTION
Rather than crashing your HTTP server, the entire operation pipeline is wrapped in a recovery middleware that converts the panic to a 500-style error.